### PR TITLE
Update core.yml

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -412,7 +412,7 @@ core:
       posts_empty_text: 暫無回覆。
       posts_link: => core.ref.posts
       posts_load_more_button: => core.ref.load_more
-      posts_link: 回覆
+      #posts_link: 回覆
       settings_link: => core.ref.settings
 
     # These translations are found on the user profile page (admin function).


### PR DESCRIPTION
Fix Error on Flarum 0.1.0-beta.16.
The error is due to a duplicated line. Removing "posts_link: 回覆" (line 415) at "PATH_TO_FLARUM/vendor/csineneo/lang-traditional-chinese/locale/core.yml" session seems to have the problem fixed.